### PR TITLE
Fix api artifact being unresolvable via modrinth

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -16,7 +16,7 @@ val base: Project = requireNotNull(stonecutter.node.sibling("")?.project) {
 version = "${mod.version}+$minecraft"
 group = "${mod.group}.${mod.id}.api.$loader"
 base {
-    archivesName.set("${mod.id}-api")
+    archivesName.set("${mod.id}")
 }
 
 val shadowBundle: Configuration by configurations.creating {
@@ -126,7 +126,7 @@ java {
 tasks.remapJar {
     injectAccessWidener = true
     inputFile = tasks.shadowJar.get().archiveFile
-    archiveClassifier = loader.toString()
+    archiveClassifier = loader.toString() + "-api"
     dependsOn(tasks.shadowJar)
 }
 


### PR DESCRIPTION
Currently, it's not possible to get the api artifact via Modrinth's maven as the `api` suffix is appended onto the end of the artifact base name, rather than the full artifact file name. As the only way to access a version's artifacts is by using `dynamiccrosshair` as the artifact id and the version as the corresponding version, so the current location of `api` in the name makes it unreachable. I believe setting `api` as the api project's main classifier will fix this.

The last version I could get working was 9.5, which supports this placement of the classifier.

I haven't tested this as I couldn't get lib-bamboo to build to my local maven repo - separate issue. Apologies about that. This should be valid syntax hopefully.

<img width="800" height="70" alt="image" src="https://github.com/user-attachments/assets/e306a68d-e18e-4592-85b4-425f2ed6fbeb" />

<img width="412" height="169" alt="image" src="https://github.com/user-attachments/assets/433e066f-92cf-4c03-853c-57a84211eb60" />

<img width="800" height="80" alt="image" src="https://github.com/user-attachments/assets/e2e7ed48-9aff-44e5-91b7-039c6eda6802" />
